### PR TITLE
 smoothquant fp8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,20 @@ For currenttly supported models, config should be like:
   "qkv": "per-tensor",
   "out": "per-tensor",
   "fc1": "per-tensor",
-  "fc2": "per-tensor"
+  "fc2": "per-tensor",
+  "type": "int8"
 }
 ```
 
 "qkv" stands for QKV matmul of attention, "out" stands for out matmul of attention.
-"fc1" and "fc2" are the layers of the FFNs, which might be referred to as "gate_up" and "down" in Llama-like models.
+"fc1" and "fc2" are the layers of the FFNs, which might be referred to as "gate_up" and "down" in Llama-like models. 
 You can set the value to "per-tensor" or "per-token" to perform the quant granularity you want.
+"type" stands for which kind of datatype you want to quantize model into. Currently we support int8 and fp8(e4m3).
 
 Once config is set, generate scales and do model quantization with following command:
 ```
 cd autosmoothquant/examples
-python3 smoothquant_model.py --model-path=/path/to/model --quantize-model=True --generate-scale=True --dataset-path=/path/to/dataset --smooth-strength=0.5
+python3 smoothquant_model.py --model-path /path/to/model --dataset-path /path/to/dataset --smooth-strength 0.5 --quantize-model --generate-scale
 ```
 
 use following command for more information 
@@ -60,7 +62,8 @@ python smoothquant_model.py -help
     "qkv": "per-tensor",
     "out": "per-token",
     "fc1": "per-tensor",
-    "fc2": "per-token"
+    "fc2": "per-token",
+    "type": "int8"
   }
   ```
   
@@ -68,7 +71,7 @@ python smoothquant_model.py -help
 - inference in this repo
 ```
 cd autosmoothquant/examples
-python3 test_model.py --model-path=/path/to/model --tokenizer-path=/path/to/tokenizer --model-class=llama --prompt="something to say"
+python3 test_model.py --model-path /path/to/model --tokenizer-path /path/to/tokenizer --model-class llama --prompt="something to say"
 ```
 
 ### benchmark

--- a/autosmoothquant/examples/eval_model.py
+++ b/autosmoothquant/examples/eval_model.py
@@ -1,73 +1,94 @@
-
-import torch
-import os
 from tqdm import tqdm
 import argparse
 import collections
+import os
+import torch
+import torch.nn as nn
+from transformers import AutoTokenizer
+from autosmoothquant.models import QuantizedLlamaForCausalLM, Int8OPTForCausalLM, Int8BaichuanForCausalLM, \
+    Int8MixtralForCausalLM
+from autosmoothquant.utils import parse_quant_config
+import lm_eval
+from lm_eval import tasks, simple_evaluate
+from lm_eval.models.huggingface import HFLM
+from autosmoothquant.utils import (
+    get_loaders,
+    pattern_match,
+    update_results,
+    setup_seed,
+    get_config,
+    get_model_architecture,
+    build_model_and_tokenizer
+)
 
-from benchmarks import evaluator
-from benchmarks.models.quant_model import quant_model
-from benchmarks.utils import make_table, pattern_match
-from lm_eval.tasks import TaskManager
-from autosmoothquant.utils import parse_quant_config, get_loaders
 
-def parse_args():                                                                                                                                                                                                                                                                                                                               
+def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model-path', type=str,
-                        default='int8-models/llama-13b', help='path contains model weight and quant config')
-    parser.add_argument('--tokenizer-path', type=str,
-                        default='int8-models/llama-13b', help='path contains tokenizer')
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default="",
+        help="path contains model weight and quant config",
+    )
+    parser.add_argument(
+        "--tokenizer-path",
+        type=str,
+        default="",
+        help="path contains tokenizer",
+    )
     parser.add_argument("--tasks", default="")
-    parser.add_argument("--eval_ppl", action="store_true", default=True)
-    parser.add_argument("--batch_size", type=int, default=8)
-    parser.add_argument("--limit", type=int, default=None)
-    parser.add_argument("--num_fewshot", type=int, default=0)
+    parser.add_argument("--eval-ppl", action="store_true", default=True)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--max-length", type=int, default=2048)
+    parser.add_argument("--num-fewshot", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--origin-model", action="store_true", default=False)
+    parser.add_argument('--model-class', type=str,
+                        default='llama', help='currently support: llama, baichuan, opt, mixtral')
     return parser.parse_args()
 
 
-def update_results(results, new_result):
-    for key, value in new_result.items():
-        if key in results:
-            results[key].update(value)
-        else:
-            results.update({key: value})
-
-
 @torch.no_grad()
-def benchmarks(lm, args):
-    # for task in ["wikitext2", "c4"]:
+def eval_model(model, tokenizer, args):
+    max_length = args.max_length
     results = {}
+    # eval ppl
     if args.eval_ppl:
         for task in ["wikitext2"]:
             _, testloader = get_loaders(
                 task,
-                seed=args.seed,
+                seed=0,
                 model=args.tokenizer_path,
-                seqlen=lm.max_length,
+                seqlen=max_length,
             )
             if "c4" in task:
                 testenc = testloader
             else:
                 testenc = testloader.input_ids
 
-            nsamples = testenc.numel() // lm.max_length
-            lm.model.eval()
+            nsamples = testenc.numel() // max_length
+
             nlls = []
             for i in tqdm(range(nsamples)):
-                batched_inps = testenc[
-                    :, (i * lm.max_length) : ((i + 1) * lm.max_length)
-                ].to("cuda:0")
-                batched_labels = testenc[
-                    :, (i * lm.max_length) : ((i + 1) * lm.max_length)
-                ].to(lm.model.lm_head.weight.device)
-                loss = lm.model(batched_inps, labels=batched_labels).loss
-                neg_log_likelihood = loss.float() * lm.max_length
+                batched_inps = testenc[:, (i * max_length): ((i + 1) * max_length)].to(
+                    model.device
+                )
+                outputs = model.model(batched_inps)
+                hidden_states = outputs[0]
+                logits = model.lm_head(hidden_states)
+                shift_logits = logits[:, :-1, :]
+                shift_labels = testenc[:, (i * max_length): ((i + 1) * max_length)][
+                               :, 1:
+                               ].to(model.lm_head.weight.device)
+                loss_fct = nn.CrossEntropyLoss()
+                loss = loss_fct(
+                    shift_logits.view(-1, shift_logits.size(-1)),
+                    shift_labels.view(-1),
+                )
+                neg_log_likelihood = loss.float() * max_length
                 nlls.append(neg_log_likelihood)
-                if i == args.limit:
-                    break
 
-            ppl = torch.exp(torch.stack(nlls).sum() / (nsamples * lm.max_length))
+            ppl = torch.exp(torch.stack(nlls).sum() / (nsamples * max_length))
 
             result = collections.defaultdict(dict)
             versions = collections.defaultdict(dict)
@@ -80,29 +101,59 @@ def benchmarks(lm, args):
                 "versions": dict(versions),
                 "n-shot": dict(n_shot),
             }
+            print(t_results)
             update_results(results, t_results)
-    if args.tasks != "":
-        t_results = evaluator.simple_evaluate(
+    # eval other datasets
+    if args.tasks != "" and args.tasks != "wikitext2":
+        task_names = pattern_match(args.tasks.split(","), tasks.TaskManager().all_tasks)
+        lm = HFLM(
+            pretrained=model,
+            backend="causal",
+            device="cuda",
+            batch_size=args.batch_size,
+            tokenizer=tokenizer,
+            max_lengt=max_length,
+        )
+        t_results = simple_evaluate(
             lm,
-            tasks=pattern_match(args.tasks.split(","), TaskManager().all_tasks),
+            tasks=task_names,
             num_fewshot=args.num_fewshot,
-            limit=args.limit,
             batch_size=args.batch_size,
         )
         update_results(results, t_results)
-    return results
+
+    print(lm_eval.utils.make_table(results))
 
 
 if __name__ == "__main__":
     args = parse_args()
-    config_path = os.path.join(args.model_path, "quant_config.json")
-    quant_config = parse_quant_config(config_path)
+    setup_seed(args.seed)
+    config = get_config(args.model_path)
 
-    lm = quant_model(
-        pretrained=args.model_path,
-        batch_size=args.batch_size,
-        quant_config=quant_config,
-        tokenizer=args.tokenizer_path,
-    )
-    results = benchmarks(lm, args)
-    print(make_table(results))
+    if args.origin_model:
+        model, tokenizer = build_model_and_tokenizer(args.model_path)
+    else:
+        config_path = os.path.join(args.model_path, "quant_config.json")
+        quant_config = parse_quant_config(config_path)
+        if args.model_class == "llama":
+            model = QuantizedLlamaForCausalLM.from_pretrained(args.model_path, quant_config,
+                                                              attn_implementation="eager", device_map="sequential")
+        elif args.model_class == "baichuan":
+            model = Int8BaichuanForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager",
+                                                            device_map="sequential")
+        elif args.model_class == "opt":
+            model = Int8OPTForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager",
+                                                       device_map="sequential")
+        elif args.model_class == "mixtral":
+            model = Int8MixtralForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager",
+                                                           device_map="sequential")
+        else:
+            raise ValueError(
+                f"Model type {args.model_class} are not supported for now.")
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.tokenizer_path,
+            trust_remote_code=True,
+        )
+    eval_model(model, tokenizer, args)
+

--- a/autosmoothquant/examples/smoothquant_model.py
+++ b/autosmoothquant/examples/smoothquant_model.py
@@ -1,27 +1,35 @@
 import torch
 import argparse
 import os
+import json
 from pathlib import Path
 
 from autosmoothquant.quantize.smooth import smooth_lm
-from autosmoothquant.quantize.calibration import get_act_scales, get_static_decoder_layer_scales
+from autosmoothquant.quantize.calibration import get_act_scales, get_static_decoder_layer_scales, \
+    quantize_activations_fp8
 from autosmoothquant.utils import get_config, get_model_architecture, build_model_and_tokenizer, parse_quant_config
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--model-path', type=str,
                         default='models/llama-13b', help='model path contains weights and config etc')
-    parser.add_argument('--quantize-model',action="store_true",
-                        help='whether to quant model or not')
+    parser.add_argument('--quantize-model', action="store_true",
+                        help='whether to quant model or not', default=True)
     parser.add_argument('--generate-scale', action="store_true",
-                        help='whether to generate scale or not')
-    parser.add_argument('--dataset-path', type=str, default='dataset/val.jsonl.zst',
+                        help='whether to generate scale or not', default=True)
+    parser.add_argument('--dataset-path', type=str, default='/home/admin/val.jsonl.zst',
                         help='location of the calibration dataset')
     parser.add_argument('--scale-output', type=str, default='scales/llama-13b',
                         help='where to save the act scales, activate when generating scales')
-    parser.add_argument("--scale-input", type=str, default='scales/llama-13b',
+    parser.add_argument("--scale-input", type=str, default='/home/admin',
                         help='where to save the act scales, activate when quantizing models')
-    parser.add_argument('--num-samples', type=int, default=512)
+    parser.add_argument('--num-samples', type=int, default=128)
+    parser.add_argument('--type', type=str, default="int8",
+                        help='fp8 & fp8_e4m3, fp8_e5m2 or int8, when quant_config.json does not have this '
+                             'configuration, this configuration will be used')
+    parser.add_argument('--activation-scheme', type=str, default="dynamic", help='dynamic or static, just for fp8')
+    parser.add_argument('--ignore-patterns', type=str, default="re:.*lm_head", help='ignore layer, just for fp8')
     parser.add_argument('--seq-len', type=int, default=512)
     parser.add_argument("--model-output", type=str, default='quantized_model/llama-13b',
                         help='where to save the quantized models, activate when quantizing models')
@@ -39,31 +47,57 @@ def main():
         print(f'Cannot find the dataset at {args.dataset_path}')
         print('Please download the dataset and put the validation set at the path')
         raise FileNotFoundError
-    
+
     if args.generate_scale:
         act_scales = get_act_scales(model, tokenizer, args.dataset_path,
-                                args.num_samples, args.seq_len)
+                                    args.num_samples, args.seq_len)
         os.makedirs(os.path.dirname(args.scale_output), exist_ok=True)
         torch.save(act_scales, args.scale_output)
-    
+
     if args.quantize_model:
         act_scales = torch.load(args.scale_input)
         smooth_lm(model, act_scales, args.smooth_strength)
         config = get_config(args.model_path)
         quant_model_class, model_type = get_model_architecture(config)
-        decoder_layer_scales, _ = get_static_decoder_layer_scales(model,
-                                                                  tokenizer,
-                                                                  args.dataset_path,
-                                                                  num_samples=args.num_samples,
-                                                                  seq_len=args.seq_len,
-                                                                  model_type=model_type)
-        output_path = Path(args.model_output) / (Path(args.model_path).name + "-smoothquant")
-
         config_path = os.path.join(args.model_path, "quant_config.json")
         quant_config = parse_quant_config(config_path)
-        int8_model = quant_model_class.from_float(model, decoder_layer_scales, quant_config)
-        
-        int8_model.save_pretrained(output_path)
+
+        if not "type" in quant_config.keys():
+            quant_config['type'] = args.type
+            if not "activation_scheme" in quant_config.keys():
+                quant_config['activation_scheme'] = args.activation_scheme
+        if quant_config['type'] == "fp8":
+            quant_config['type'] = "fp8_e4m3"
+
+        # todo(huangtingwei)
+
+        if quant_config['type'] == "fp8_e4m3":
+            if quant_config['activation_scheme'] == "static":
+                output_path = Path(args.model_output) / (Path(args.model_path).name + "-smoothquant-fp8-e4m3-static")
+                quantize_activations_fp8(model, tokenizer, args.dataset_path, args.ignore_patterns, args.num_samples)
+            else:
+                output_path = Path(args.model_output) / (Path(args.model_path).name + "-smoothquant-fp8-e4m3-dynamic")
+            quant_model = quant_model_class.from_float_to_fp8(model, quant_config)
+
+        elif quant_config['type'] == "fp8_e5m2":
+            output_path = Path(args.model_output) / (Path(args.model_path).name + "-smoothquant-fp8-e5m2")
+            quant_model = quant_model_class.from_float_to_fp8(model, quant_config)
+
+        else:
+            output_path = Path(args.model_output) / (Path(args.model_path).name + "-smoothquant-int8")
+            decoder_layer_scales, _ = get_static_decoder_layer_scales(model,
+                                                                      tokenizer,
+                                                                      args.dataset_path,
+                                                                      num_samples=args.num_samples,
+                                                                      seq_len=args.seq_len,
+                                                                      model_type=model_type)
+            quant_model = quant_model_class.from_float_to_int8(model, decoder_layer_scales, quant_config)
+
+        quant_model.save_pretrained(output_path)
+        config_output = os.path.join(output_path, "quant_config.json")
+        with open(config_output, 'w') as json_file:
+            json.dump(quant_config, json_file, indent=4)
+
 
 if __name__ == '__main__':
     main()

--- a/autosmoothquant/examples/test_model.py
+++ b/autosmoothquant/examples/test_model.py
@@ -3,7 +3,7 @@ import torch
 import argparse
 import json
 
-from autosmoothquant.models import Int8LlamaForCausalLM, Int8OPTForCausalLM, Int8BaichuanForCausalLM, Int8MixtralForCausalLM
+from autosmoothquant.models import QuantizedLlamaForCausalLM, Int8OPTForCausalLM, Int8BaichuanForCausalLM, Int8MixtralForCausalLM
 from autosmoothquant.utils import parse_quant_config
 from transformers import AutoTokenizer
 
@@ -16,7 +16,7 @@ def parse_args():
     parser.add_argument('--model-class', type=str,
                         default='llama', help='currently support: llama, baichuan, opt, mixtral')
     parser.add_argument('--prompt', type=str,
-                        default='You are right, But Genshin Impact is', help='prompts')   
+                        default='You are right, But Genshin Impact is', help='prompts')
     args = parser.parse_args()
     return args
 
@@ -32,7 +32,7 @@ def main():
     # Consider setting the default data type to torch.float16 to speed up, but this may decrease model performance.
     # torch.set_default_dtype(torch.float16)
     if args.model_class == "llama":
-      model = Int8LlamaForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager", device_map="sequential")
+      model = QuantizedLlamaForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager", device_map="sequential")
     elif args.model_class == "baichuan":
       model = Int8BaichuanForCausalLM.from_pretrained(args.model_path, quant_config, attn_implementation="eager", device_map="sequential")
     elif args.model_class == "opt":

--- a/autosmoothquant/models/__init__.py
+++ b/autosmoothquant/models/__init__.py
@@ -1,12 +1,12 @@
 from .baichuan import Int8BaichuanForCausalLM
-from .llama import Int8LlamaForCausalLM
+from .llama import QuantizedLlamaForCausalLM
 from .mixtral import Int8MixtralForCausalLM
 from .opt import Int8OPTForCausalLM
 from autosmoothquant.thirdparty.baichuan.configuration_baichuan import BaichuanConfig
 
 _MODEL_REGISTRY = {
-    "LlamaForCausalLM": Int8LlamaForCausalLM,
-    "LLaMAForCausalLM": Int8LlamaForCausalLM,
+    "LlamaForCausalLM": QuantizedLlamaForCausalLM,
+    "LLaMAForCausalLM": QuantizedLlamaForCausalLM,
     "BaichuanForCausalLM": Int8BaichuanForCausalLM,
     "OPTForCausalLM": Int8OPTForCausalLM,
     "MixtralForCausalLM": Int8MixtralForCausalLM

--- a/autosmoothquant/models/llama.py
+++ b/autosmoothquant/models/llama.py
@@ -8,33 +8,42 @@ from transformers.models.llama.modeling_llama import (
     LlamaPreTrainedModel,
     LlamaModel,
     LlamaForCausalLM,
+    LlamaRotaryEmbedding
 )
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.activations import ACT2FN
 from typing import Optional
-from autosmoothquant.layers.nn.linear import W8A8BFP32OFP32LinearWithQuantScale, W8A8BFP32OFP32Linear
+from autosmoothquant.layers.nn.linear import (
+    W8A8BFP32OFP32LinearWithQuantScale,
+    W8A8BFP32OFP32Linear,
+    FP8LinearDynamic,
+    FP8LinearStatic, FP8E5M2Linear
+)
 from transformers.utils import logging
+
 logger = logging.get_logger(__name__)
 
-class Int8LlamaRMSNorm(LlamaRMSNorm):
-    
+
+class QuantizedLlamaRMSNorm(LlamaRMSNorm):
+
     @staticmethod
     def from_float(module: LlamaRMSNorm,
-                   output_scale: float):
-        int8_module = Int8LlamaRMSNorm(module.weight.numel(), module.variance_epsilon)
+                   input_scale: float):
+        quantized_module = QuantizedLlamaRMSNorm(module.weight.numel(), module.variance_epsilon)
 
-        int8_module.weight.to(module.weight.dtype)
-        int8_module.weight = nn.Parameter(module.weight / output_scale)
+        quantized_module.weight.to(module.weight.dtype)
+        quantized_module.weight = nn.Parameter(module.weight / input_scale)
 
-        return int8_module
+        return quantized_module
 
-class Int8LlamaAttention(nn.Module):
+
+class QuantizedLlamaAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
     def __init__(
-        self,
-        config: LlamaConfig,
-        quant_config: dict[str, str],
-        layer_idx: Optional[int] = None
+            self,
+            config: LlamaConfig,
+            quant_config: dict[str, str],
+            layer_idx: Optional[int] = None
     ):
         super().__init__()
         self.config = config
@@ -64,36 +73,110 @@ class Int8LlamaAttention(nn.Module):
         
         self.qkv_quant_type = quant_config["qkv"]
         self.o_quant_type = quant_config["out"]
-        self.k_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_heads * self.head_dim, act_quant=self.qkv_quant_type)
-        self.v_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_heads * self.head_dim, act_quant=self.qkv_quant_type)
-        self.q_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_heads * self.head_dim, act_quant=self.qkv_quant_type)
-        self.o_proj = W8A8BFP32OFP32LinearWithQuantScale(self.num_heads * self.head_dim, self.hidden_size, act_quant=self.o_quant_type)
-        self._init_rope()
-    
+        if quant_config["type"] == "fp8_e4m3":
+            if quant_config["activation_scheme"] == "static":
+                self.k_proj = FP8LinearStatic(self.hidden_size, self.num_key_value_heads * self.head_dim)
+                self.v_proj = FP8LinearStatic(self.hidden_size, self.num_key_value_heads * self.head_dim)
+                self.q_proj = FP8LinearStatic(self.hidden_size, self.num_heads * self.head_dim)
+                self.o_proj = FP8LinearStatic(self.num_heads * self.head_dim, self.hidden_size)
+            else:
+                self.k_proj = FP8LinearDynamic(self.hidden_size, self.num_key_value_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+                self.v_proj = FP8LinearDynamic(self.hidden_size, self.num_key_value_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+                self.q_proj = FP8LinearDynamic(self.hidden_size, self.num_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+                self.o_proj = FP8LinearDynamic(self.num_heads * self.head_dim, self.hidden_size,
+                                               act_quant=self.o_quant_type)
+
+        elif quant_config["type"] == "fp8_e5m2":
+            self.k_proj = FP8E5M2Linear(self.hidden_size, self.num_key_value_heads * self.head_dim)
+            self.v_proj = FP8E5M2Linear(self.hidden_size, self.num_key_value_heads * self.head_dim)
+            self.q_proj = FP8E5M2Linear(self.hidden_size, self.num_heads * self.head_dim)
+            self.o_proj = FP8E5M2Linear(self.num_heads * self.head_dim, self.hidden_size)
+
+        else:
+            self.k_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_key_value_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+            self.v_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_key_value_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+            self.q_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.num_heads * self.head_dim,
+                                               act_quant=self.qkv_quant_type)
+            self.o_proj = W8A8BFP32OFP32LinearWithQuantScale(self.num_heads * self.head_dim, self.hidden_size,
+                                                             act_quant=self.o_quant_type)
+        # self._init_rope()
+
     _init_rope = LlamaAttention._init_rope
-    _shape = LlamaAttention._shape
+    # _shape = LlamaAttention._shape
     forward = LlamaAttention.forward
     
     @staticmethod
     @torch.no_grad()
-    def from_float(module: LlamaAttention,
-                   config: LlamaConfig,
-                   quant_config: dict[str, str],
-                   attn_input_scale: float,
-                   q_output_scale: float,
-                   k_output_scale: float,
-                   v_output_scale: float,
-                   out_input_scale: float):
-        int8_module = Int8LlamaAttention(config, quant_config)
+    def from_float_to_int8(module: LlamaAttention,
+                           config: LlamaConfig,
+                           quant_config: dict[str, str],
+                           attn_input_scale: float,
+                           q_output_scale: float,
+                           k_output_scale: float,
+                           v_output_scale: float,
+                           out_input_scale: float):
+        int8_module = QuantizedLlamaAttention(config, quant_config)
         # we do not impelement attn for now bacuase we want use paged attention
-        int8_module.q_proj = W8A8BFP32OFP32Linear.from_float(module.q_proj, attn_input_scale, act_quant=int8_module.qkv_quant_type)
-        int8_module.k_proj = W8A8BFP32OFP32Linear.from_float(module.k_proj, attn_input_scale, act_quant=int8_module.qkv_quant_type)
-        int8_module.v_proj = W8A8BFP32OFP32Linear.from_float(module.v_proj, attn_input_scale, act_quant=int8_module.qkv_quant_type)
+        int8_module.q_proj = W8A8BFP32OFP32Linear.from_float(module.q_proj, attn_input_scale,
+                                                             act_quant=int8_module.qkv_quant_type)
+        int8_module.k_proj = W8A8BFP32OFP32Linear.from_float(module.k_proj, attn_input_scale,
+                                                             act_quant=int8_module.qkv_quant_type)
+        int8_module.v_proj = W8A8BFP32OFP32Linear.from_float(module.v_proj, attn_input_scale,
+                                                             act_quant=int8_module.qkv_quant_type)
         int8_module.o_proj = W8A8BFP32OFP32LinearWithQuantScale.from_float(
             module.o_proj, out_input_scale, act_quant=int8_module.o_quant_type)
         return int8_module
-    
-class Int8LlamaMLP(nn.Module):
+
+    @staticmethod
+    @torch.no_grad()
+    def from_float_to_fp8(module: LlamaAttention,
+                          config: LlamaConfig,
+                          quant_config: dict[str, str]
+                          ):
+        fp8_module = QuantizedLlamaAttention(config, quant_config)
+        # fp8_e5m2
+        if quant_config["type"] == "fp8_e5m2":
+            """
+            fp8_e5m2 only support per tensor
+            """
+            assert quant_config["qkv"] == "per-tensor"
+            assert quant_config["out"] == "per-tensor"
+            fp8_module.q_proj = FP8E5M2Linear.from_float(module.q_proj)
+            fp8_module.k_proj = FP8E5M2Linear.from_float(module.k_proj)
+            fp8_module.v_proj = FP8E5M2Linear.from_float(module.v_proj)
+            fp8_module.o_proj = FP8E5M2Linear.from_float(module.o_proj)
+
+        # fp8_e4m3
+        elif quant_config["type"] == "fp8_e4m3":
+            if quant_config["activation_scheme"] == "static":
+                """
+                fp8_e4m3 static only support per tensor
+                """
+                assert quant_config["qkv"] == "per-tensor"
+                assert quant_config["out"] == "per-tensor"
+                fp8_module.q_proj = FP8LinearStatic.from_float(module.q_proj)
+                fp8_module.k_proj = FP8LinearStatic.from_float(module.k_proj)
+                fp8_module.v_proj = FP8LinearStatic.from_float(module.v_proj)
+                fp8_module.o_proj = FP8LinearStatic.from_float(module.o_proj)
+
+            # Dynamic
+            else:
+                fp8_module.q_proj = FP8LinearDynamic.from_float(module.q_proj)
+                fp8_module.k_proj = FP8LinearDynamic.from_float(module.k_proj)
+                fp8_module.v_proj = FP8LinearDynamic.from_float(module.v_proj)
+                fp8_module.o_proj = FP8LinearDynamic.from_float(module.o_proj)
+
+        else:
+            raise ValueError(f"Unsupported quant type: {quant_config['type']}")
+        return fp8_module
+
+
+class QuantizedLlamaMLP(nn.Module):
     def __init__(self, config: LlamaConfig, quant_config: dict[str, str]):
         super().__init__()
         self.config = config
@@ -101,60 +184,129 @@ class Int8LlamaMLP(nn.Module):
         self.intermediate_size = config.intermediate_size
         self.gate_up_quant_type = quant_config["fc1"]
         self.down_quant_type = quant_config["fc2"]
-        self.gate_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.intermediate_size, act_quant=self.gate_up_quant_type)
-        self.up_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.intermediate_size, act_quant=self.gate_up_quant_type)
-        self.down_proj = W8A8BFP32OFP32LinearWithQuantScale(self.intermediate_size, self.hidden_size, act_quant=self.down_quant_type)
+        if quant_config["type"] == "fp8_e4m3":
+            if quant_config["activation_scheme"] == "static":
+                self.gate_proj = FP8LinearStatic(self.hidden_size, self.intermediate_size)
+                self.up_proj = FP8LinearStatic(self.hidden_size, self.intermediate_size)
+                self.down_proj = FP8LinearStatic(self.intermediate_size, self.hidden_size)
+            else:
+                self.gate_proj = FP8LinearDynamic(self.hidden_size, self.intermediate_size,
+                                                  act_quant=self.gate_up_quant_type)
+                self.up_proj = FP8LinearDynamic(self.hidden_size, self.intermediate_size,
+                                                act_quant=self.gate_up_quant_type)
+                self.down_proj = FP8LinearDynamic(self.intermediate_size, self.hidden_size,
+                                                  act_quant=self.down_quant_type)
+
+        elif quant_config["type"] == "fp8_e5m2":
+            self.gate_proj = FP8E5M2Linear(self.hidden_size, self.intermediate_size)
+            self.up_proj = FP8E5M2Linear(self.hidden_size, self.intermediate_size)
+            self.down_proj = FP8E5M2Linear(self.intermediate_size, self.hidden_size)
+
+        elif quant_config["type"] == "int8":
+            self.gate_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.intermediate_size,
+                                                  act_quant=self.gate_up_quant_type)
+            self.up_proj = W8A8BFP32OFP32Linear(self.hidden_size, self.intermediate_size,
+                                                act_quant=self.gate_up_quant_type)
+            self.down_proj = W8A8BFP32OFP32LinearWithQuantScale(self.intermediate_size, self.hidden_size,
+                                                                act_quant=self.down_quant_type)
+
+        else:
+            raise ValueError(f"Unsupported quant type: {quant_config['type']}")
+
         self.act_fn = ACT2FN[config.hidden_act]
-    
+
     forward = LlamaMLP.forward
 
     @staticmethod
     @torch.no_grad()
-    def from_float(module: LlamaMLP,
-                   config: LlamaConfig,
-                   quant_config: dict[str, str],
-                   gate_input_scale: float,
-                   down_input_scale: float):
-        int8_module = Int8LlamaMLP(config, quant_config)
-        int8_module.gate_proj = W8A8BFP32OFP32Linear.from_float(module.gate_proj, gate_input_scale, act_quant=int8_module.gate_up_quant_type)
-        int8_module.up_proj = W8A8BFP32OFP32Linear.from_float(module.up_proj, gate_input_scale, act_quant=int8_module.gate_up_quant_type)
+    def from_float_to_int8(module: LlamaMLP,
+                           config: LlamaConfig,
+                           quant_config: dict[str, str],
+                           gate_input_scale: float,
+                           down_input_scale: float):
+        int8_module = QuantizedLlamaMLP(config, quant_config)
+        int8_module.gate_proj = W8A8BFP32OFP32Linear.from_float(module.gate_proj, gate_input_scale,
+                                                                act_quant=int8_module.gate_up_quant_type)
+        int8_module.up_proj = W8A8BFP32OFP32Linear.from_float(module.up_proj, gate_input_scale,
+                                                              act_quant=int8_module.gate_up_quant_type)
         int8_module.down_proj = W8A8BFP32OFP32LinearWithQuantScale.from_float(
-            module.down_proj, 
+            module.down_proj,
             down_input_scale,
             act_quant=int8_module.down_quant_type)
         return int8_module
-    
-class Int8LlamaDecoderLayer(nn.Module):
+
+    @staticmethod
+    @torch.no_grad()
+    def from_float_to_fp8(module: LlamaMLP,
+                          config: LlamaConfig,
+                          quant_config: dict[str, str]):
+        fp8_module = QuantizedLlamaMLP(config, quant_config)
+
+        # fp8_e5m2
+        if quant_config["type"] == "fp8_e5m2":
+            """
+            fp8_e5m2 only support per tensor
+            """
+            assert quant_config["qkv"] == "per-tensor"
+            assert quant_config["out"] == "per-tensor"
+            fp8_module.gate_proj = FP8E5M2Linear.from_float(module.gate_proj)
+            fp8_module.up_proj = FP8E5M2Linear.from_float(module.up_proj)
+            fp8_module.down_proj = FP8E5M2Linear.from_float(module.down_proj)
+
+        # fp8_e4m3
+        elif quant_config["type"] == "fp8_e4m3":
+            if quant_config["activation_scheme"] == "static":
+                """
+                fp8_e4m3 static only support per tensor
+                """
+                assert quant_config["qkv"] == "per-tensor"
+                assert quant_config["out"] == "per-tensor"
+                fp8_module.gate_proj = FP8LinearStatic.from_float(module.gate_proj)
+                fp8_module.up_proj = FP8LinearStatic.from_float(module.up_proj)
+                fp8_module.down_proj = FP8LinearStatic.from_float(module.down_proj)
+
+            # Dynamic
+            else:
+                fp8_module.gate_proj = FP8LinearDynamic.from_float(module.gate_proj)
+                fp8_module.up_proj = FP8LinearDynamic.from_float(module.up_proj)
+                fp8_module.down_proj = FP8LinearDynamic.from_float(module.down_proj)
+
+        else:
+            raise ValueError(f"Unsupported quant type: {quant_config['type']}")
+        return fp8_module
+
+
+class QuantizedLlamaDecoderLayer(nn.Module):
     def __init__(self, config: LlamaConfig, quant_config: dict[str, str], layer_idx: int):
         super().__init__()
         self.hidden_size = config.hidden_size
         # only support LlamaAttention for now. TODO: support LlamaFlashAttention2 and LlamaSdpaAttention
-        self.self_attn = Int8LlamaAttention(config, quant_config, layer_idx)
-        self.mlp = Int8LlamaMLP(config, quant_config)
-        self.input_layernorm = Int8LlamaRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = Int8LlamaRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn = QuantizedLlamaAttention(config, quant_config, layer_idx)
+        self.mlp = QuantizedLlamaMLP(config, quant_config)
+        self.input_layernorm = LlamaRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = LlamaRMSNorm(self.hidden_size, eps=config.rms_norm_eps)
 
     forward = LlamaDecoderLayer.forward
 
     @staticmethod
-    def from_float(module: LlamaDecoderLayer,
-                   config: LlamaConfig,
-                   quant_config: dict[str, str],
-                   attn_input_scale: float,
-                   q_output_scale: float,
-                   k_output_scale: float,
-                   v_output_scale: float,
-                   out_input_scale: float,
-                   gate_input_scale: float,
-                   down_input_scale: float
-                   ):
-        int8_module = Int8LlamaDecoderLayer(
+    def from_float_to_int8(module: LlamaDecoderLayer,
+                           config: LlamaConfig,
+                           quant_config: dict[str, str],
+                           attn_input_scale: float,
+                           q_output_scale: float,
+                           k_output_scale: float,
+                           v_output_scale: float,
+                           out_input_scale: float,
+                           gate_input_scale: float,
+                           down_input_scale: float
+                           ):
+        quantized_module = QuantizedLlamaDecoderLayer(
             config,
             quant_config,
             module.self_attn.layer_idx
         )
-        int8_module.self_attn = Int8LlamaAttention.from_float(
-            module.self_attn, 
+        quantized_module.self_attn = QuantizedLlamaAttention.from_float_to_int8(
+            module.self_attn,
             config,
             quant_config,
             attn_input_scale,
@@ -163,40 +315,57 @@ class Int8LlamaDecoderLayer(nn.Module):
             v_output_scale,
             out_input_scale
         )
-        int8_module.mlp = Int8LlamaMLP.from_float(
-            module.mlp, 
+        quantized_module.mlp = QuantizedLlamaMLP.from_float_to_int8(
+            module.mlp,
             config,
             quant_config,
             gate_input_scale,
             down_input_scale
         )
+        # only per tensor need to apply input sclae to layernorm
         if quant_config["qkv"] == "per-tensor":
-            int8_module.input_layernorm = Int8LlamaRMSNorm.from_float(
+            quantized_module.input_layernorm = QuantizedLlamaRMSNorm.from_float(
                 module.input_layernorm,
                 attn_input_scale
             )
         else:
-            int8_module.input_layernorm = module.input_layernorm
+            quantized_module.input_layernorm = module.input_layernorm
         if quant_config["fc1"] == "per-tensor":
-            int8_module.post_attention_layernorm = Int8LlamaRMSNorm.from_float(
+            quantized_module.post_attention_layernorm = QuantizedLlamaRMSNorm.from_float(
                 module.post_attention_layernorm,
                 gate_input_scale
             )
         else:
-            int8_module.post_attention_layernorm = module.post_attention_layernorm
-        return int8_module
-    
-class Int8LlamaModel(LlamaPreTrainedModel):
+            quantized_module.post_attention_layernorm = module.post_attention_layernorm
+        return quantized_module
+
+    @staticmethod
+    def from_float_to_fp8(module: LlamaDecoderLayer, config: LlamaConfig, quant_config: dict[str, str]):
+        quantized_module = QuantizedLlamaDecoderLayer(
+            config,
+            quant_config,
+            module.self_attn.layer_idx
+        )
+        quantized_module.self_attn = QuantizedLlamaAttention.from_float_to_fp8(module.self_attn, config, quant_config)
+        quantized_module.mlp = QuantizedLlamaMLP.from_float_to_fp8(module.mlp, config, quant_config)
+        quantized_module.input_layernorm = module.input_layernorm
+        quantized_module.post_attention_layernorm = module.post_attention_layernorm
+        return quantized_module
+
+
+class QuantizedLlamaModel(LlamaPreTrainedModel):
     def __init__(self, config: LlamaConfig, quant_config: dict[str, str]):
         super().__init__(config)
         self.config = config
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
-        self.layers = nn.ModuleList([Int8LlamaDecoderLayer(config, quant_config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.layers = nn.ModuleList([QuantizedLlamaDecoderLayer(config, quant_config, layer_idx) for layer_idx in
+                                     range(config.num_hidden_layers)])
         self._use_sdpa = config._attn_implementation == "sdpa"
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
         self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = LlamaRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
         # Initialize weights and apply final processing
         self.post_init()
@@ -204,25 +373,39 @@ class Int8LlamaModel(LlamaPreTrainedModel):
     get_input_embeddings = LlamaModel.get_input_embeddings
     set_input_embeddings = LlamaModel.set_input_embeddings
     forward = LlamaModel.forward
-    
-    @staticmethod
-    def from_float(module, decoder_layer_scales, quant_config):
-        int8_module = Int8LlamaModel(module.config, quant_config)
-        
-        int8_module.embed_tokens = module.embed_tokens
-        int8_module.norm = module.norm
-        
-        for i, layer in enumerate(module.layers):
-            int8_module.layers[i] = Int8LlamaDecoderLayer.from_float(
-                layer, module.config, quant_config, **decoder_layer_scales[i])
-        return int8_module
+    _update_causal_mask = LlamaModel._update_causal_mask
 
-class Int8LlamaForCausalLM(LlamaPreTrainedModel):
+    @staticmethod
+    def from_float_to_int8(module, decoder_layer_scales, quant_config):
+        quantized_module = QuantizedLlamaModel(module.config, quant_config)
+
+        quantized_module.embed_tokens = module.embed_tokens
+        quantized_module.norm = module.norm
+
+        for i, layer in enumerate(module.layers):
+            quantized_module.layers[i] = QuantizedLlamaDecoderLayer.from_float_to_int8(
+                layer, module.config, quant_config, **decoder_layer_scales[i])
+        return quantized_module
+
+    @staticmethod
+    def from_float_to_fp8(module, quant_config):
+        quantized_module = QuantizedLlamaModel(module.config, quant_config)
+
+        quantized_module.embed_tokens = module.embed_tokens
+        quantized_module.norm = module.norm
+
+        for i, layer in enumerate(module.layers):
+            quantized_module.layers[i] = QuantizedLlamaDecoderLayer.from_float_to_fp8(layer, module.config,
+                                                                                      quant_config)
+        return quantized_module
+
+
+class QuantizedLlamaForCausalLM(LlamaPreTrainedModel):
     def __init__(self, config, quant_config):
         super().__init__(config)
         self.config = config
         self.vocab_size = config.vocab_size
-        self.model = Int8LlamaModel(config, quant_config)
+        self.model = QuantizedLlamaModel(config, quant_config)
         # no need to quant
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         # Initialize weights and apply final processing
@@ -237,12 +420,21 @@ class Int8LlamaForCausalLM(LlamaPreTrainedModel):
     forward = LlamaForCausalLM.forward
     prepare_inputs_for_generation = LlamaForCausalLM.prepare_inputs_for_generation
     _reorder_cache = LlamaForCausalLM._reorder_cache
-    
+
     @staticmethod
-    def from_float(module, decoder_layer_scales, quant_config):
-        int8_module = Int8LlamaForCausalLM(module.config, quant_config)
-        print("start trans into int8, this might take a while")
-        int8_module.model = Int8LlamaModel.from_float(
+    def from_float_to_int8(module, decoder_layer_scales, quant_config):
+        quantized_module = QuantizedLlamaForCausalLM(module.config, quant_config)
+        print("start perform weight quantization, this might take a while")
+        quantized_module.model = QuantizedLlamaModel.from_float_to_int8(
             module.model, decoder_layer_scales, quant_config)
-        int8_module.lm_head = module.lm_head
-        return int8_module   
+        quantized_module.lm_head = module.lm_head
+        return quantized_module
+
+    @staticmethod
+    def from_float_to_fp8(module, quant_config):
+        quantized_module = QuantizedLlamaForCausalLM(module.config, quant_config)
+        print("start perform weight quantization, this might take a while")
+        quantized_module.model = QuantizedLlamaModel.from_float_to_fp8(
+            module.model, quant_config)
+        quantized_module.lm_head = module.lm_head
+        return quantized_module

--- a/autosmoothquant/utils/__init__.py
+++ b/autosmoothquant/utils/__init__.py
@@ -1,2 +1,3 @@
 from .datautils import get_loaders
-from .utils import get_config, get_model_architecture, build_model_and_tokenizer, parse_quant_config
+from .utils import get_config, get_model_architecture, build_model_and_tokenizer, parse_quant_config, setup_seed
+from .eval_utils import pattern_match, update_results

--- a/autosmoothquant/utils/eval_utils.py
+++ b/autosmoothquant/utils/eval_utils.py
@@ -1,0 +1,23 @@
+import logging
+import fnmatch
+
+
+logger = logging.getLogger("QQQ")
+
+# Returns a list containing all values of the source_list that
+# match at least one of the patterns
+def pattern_match(patterns, source_list):
+    task_names = set()
+    for pattern in patterns:
+        for matching in fnmatch.filter(source_list, pattern):
+            task_names.add(matching)
+    return list(task_names)
+
+
+def update_results(results, new_result):
+    for key, value in new_result.items():
+        if key in results:
+            results[key].update(value)
+        else:
+            results.update({key: value})
+

--- a/autosmoothquant/utils/utils.py
+++ b/autosmoothquant/utils/utils.py
@@ -2,6 +2,8 @@ from typing import Optional, Type
 import json
 import torch
 from torch import nn
+import numpy as np
+import random
 
 from transformers import AutoTokenizer
 from transformers import AutoConfig, AutoModelForCausalLM, PretrainedConfig
@@ -50,3 +52,10 @@ def get_model_architecture(config) -> Type[nn.Module]:
     raise ValueError(
         f"Model architectures {architectures} are not supported for now. "
         f"Supported architectures: {list(_MODEL_REGISTRY.keys())}")
+
+def setup_seed(seed):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.backends.cudnn.deterministic = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-transformers == 4.36.2
+transformers == 4.42.3
+torch>=2.2
 datasets
 accelerate
 icecream
+tqdm
+zstandard
+lm_eval


### PR DESCRIPTION
hi~ @AniZpZ 

We have implemented smoothquant fp8 quantization. Compared with the int8 model, the fp8 model has significantly better model performance. At the same time, in comparison with the AutoFP8 method, smoothquant fp8 has a slightly lower perplexity in WikiText2. On some zero-shot tasks, smoothquant fp8 has better performance.

### Model Performance
We evaluated the model performance on WikiText2 and five zero-shot tasks. Currently only for llama2-7b.
![image](https://github.com/user-attachments/assets/9d107b25-8005-4b57-9b5b-a47a2c131d65)

![image](https://github.com/user-attachments/assets/b942a2e3-124f-4d6e-9ad3-83c00d8aca1d)

### TODO list

- support for more models
- more model evaluations
- Automatically search for smooth strength param